### PR TITLE
Update sources, fix api calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ STATIC			= true
 
 # Versions
 export BUILD_AVRDUDE	= avrdude-5.11
-export BUILD_BINUTILS	= binutils-2.25
-export BUILD_GCC	= gcc-4.9.2
+export BUILD_BINUTILS	= binutils-2.36
+export BUILD_GCC	= gcc-10.2.0
 export BUILD_BIN2HEX	= bin2hex
-export BUILD_MPC	= mpc-1.0.3
-export BUILD_MPFR	= mpfr-3.1.2
-export BUILD_GMP	= gmp-6.0.0
-export BUILD_MAKE	= make-4.1
+export BUILD_MPC	= mpc-1.2.1
+export BUILD_MPFR	= mpfr-4.1.0
+export BUILD_GMP	= gmp-6.2.1
+export BUILD_MAKE	= make-4.3
 export BUILD_LIBC	= mcb32libc-0.1
 
 export MAKESELF	= makeself-2.2.0
@@ -27,11 +27,11 @@ export MAKESELF	= makeself-2.2.0
 URLS 		= \
 	http://download.savannah.gnu.org/releases/avrdude/$(BUILD_AVRDUDE).tar.gz \
 	http://ftp.gnu.org/gnu/binutils/$(BUILD_BINUTILS).tar.bz2 \
-	http://ftp.gnu.org/gnu/gcc/$(BUILD_GCC)/$(BUILD_GCC).tar.bz2 \
+	http://ftp.gnu.org/gnu/gcc/$(BUILD_GCC)/$(BUILD_GCC).tar.gz \
 	http://ftp.gnu.org/gnu/mpc/$(BUILD_MPC).tar.gz \
-	http://ftp.gnu.org/gnu/gmp/$(BUILD_GMP)a.tar.bz2 \
+	http://ftp.gnu.org/gnu/gmp/$(BUILD_GMP).tar.bz2 \
 	http://ftp.gnu.org/gnu/mpfr/$(BUILD_MPFR).tar.bz2 \
-	http://ftp.gnu.org/gnu/make/$(BUILD_MAKE).tar.bz2 \
+	http://ftp.gnu.org/gnu/make/$(BUILD_MAKE).tar.gz \
 	https://github.com/is1200-example-projects/mcb32libc/releases/download/v0.1/$(BUILD_LIBC).tar.gz
 
 # Packages that should be downloaded
@@ -242,14 +242,14 @@ processors: binutils-install | build
 runtime: binutils-install gcc-install processors | build
 	+make -C "runtime/crt0"
 	+make -C "runtime/crtprep"
-	
+
 runtime-install: installdir runtime
 	+make -C "runtime/crt0" install
 	+make -C "runtime/crtprep" install
 
 mcb32libc: downloads/$(BUILD_LIBC) gcc-install environment | build
 	mkdir -p build/mcb32libc
-	
+
 	+AR=$(PREFIX)/bin/$(TARGET)-ar \
 		AS=$(PREFIX)/bin/$(TARGET)-as \
 		CC=$(PREFIX)/bin/$(TARGET)-gcc \
@@ -344,3 +344,4 @@ install-mac-app: installdir
 clean:
 	$(RM) -R "build"
 	@echo Done.
+

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ build the toolchain. Before you begin, run:
 This should install all required packages.
 
 You will also need about 3 GB of available disk space. The compiled toolchain
-will use about 250 MB of space in the installation directory.
+will use about 300 MB of space in the installation directory.
 
 ### Starting the build process
 First, you need to configure the target installation directory of the toolchain.
@@ -19,7 +19,7 @@ the `INSTALL_DIR` variable. The `INSTALL_DIR` variable declaration can be found 
 root makefile, located at the root of this repository.
 
 Before you can start building the toolchain, you need to create this directory and make
-sure it's writable. Do this with `sudo mkdir -p <install path>` and 
+sure it's writable. Do this with `sudo mkdir -p <install path>` and
 `sudo chown <your user> <install path>`.
 
 When you've done that, cd into the toolchain repository and run `make`.
@@ -31,7 +31,7 @@ commands to fix the problem.
 It is recommended that you build with at least as many threads as your CPU supports in
 hardware, but at most 50% more. Otherwise it may take a long time or your system may
 become overloaded. If you have 4 hardware threads, run make with `make -j6`, this will
-use 6 threads to compensate for I/O wait. If you build on an SSD or RAM disk, 
+use 6 threads to compensate for I/O wait. If you build on an SSD or RAM disk,
 4 threads may be enough. Don't provide the `-j` withough an argument, as this will build with
 unlimited threading. With a large build like this toolchain, your system will be unusable for some time
 and the build will probably fail.
@@ -117,7 +117,7 @@ You will also need about 3 GB of available disk space.
 
 ### Starting the build process
 First, you may configure the file name of the app by setting the `INSTALL_DIR`
-variable at the top of the root makefile, the variable specific for Mac OS 
+variable at the top of the root makefile, the variable specific for Mac OS
 (as indicated by comments.) A default of `/Applications/mcb32tools.app` is used,
 and it is recommended that it is not changed.
 
@@ -141,11 +141,3 @@ Applications folder. For making a release suitable for distribution, run
 `make release` and a disk image with the app will be created in the root directory
 of the repo.
 
-
-## Currently implemented hacks
-### libgmp
-At the time this toolchain was pieced together, the latest version available
-was 6.0.0a, it does however extract to 6.0.0. As a crude hack, an "a" is appended to the
-URL in the list of URLs. If you wish to update the version of libgmp, you probably
-need to remove this stray 'a'. You can find the list of URLs near the top of the
-root makefile.

--- a/bin2hex/bin2hex.c
+++ b/bin2hex/bin2hex.c
@@ -205,7 +205,7 @@ write_hex_file (char *name, bfd *abfd)
       printf ("Error: could not open file %s for writing!\n", name);
       return 1;
     }
-  
+
   if (verbose)
     {
       printf ("writing %s\n\n", name);
@@ -355,8 +355,7 @@ write_section (bfd *abfd, asection *sect, PTR fp)
   hexfile = fp;
   p = &dat[0];
   offset = 0;
-  total = (unsigned long) bfd_section_size (abfd, sect)
-        / bfd_octets_per_byte (abfd);
+  total = (unsigned long) bfd_section_size (sect) / bfd_octets_per_byte(abfd, sect);
 
   /* if section is load-able and has contents */
   if ((sect->flags & SEC_LOAD) &&
@@ -430,7 +429,7 @@ write_section (bfd *abfd, asection *sect, PTR fp)
           }
         /* add checksum */
         fprintf (hexfile, "%2.2x\n", (unsigned char) sum);
-      }    
+      }
     }
 }
 
@@ -447,5 +446,4 @@ write_extended_address_record (file_ptr base_address, PTR fp)
   sum -= (2 + 0 + 4 + (upper_addr >> 8) + (upper_addr & 0xFF));
   fprintf (hexfile, ":02000004%4.4x%2.2x\n", upper_addr, (unsigned char) sum);
 }
-
 


### PR DESCRIPTION
Update the toolchain components to more modern versions,
for better C standard support, better diagnostics, some new extensions
and overall a more closer match to the native toolchain most distributions
ship with nowadays (so people can test programs locally with their x86 gcc
without having unexpected problems when compiling for the ChipKit).

Avrdude is left to an older version because I couldn't get the newer ones to work,
but it'd be nice to port everything to a newer version so that people can use the one their
distro ships with instead of having to compile it from source.

I used it to compile the code for the labs and also most of my project,
and didn't notice any issue from the version change.

